### PR TITLE
fix: remediate Request Tracker security findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.1.7
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 Splunk Inc.
+   Copyright (c) 2016-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Request Tracker
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ summary.total_objects_successful | numeric | | 1 |
 
 Download attachment to vault
 
-Type: **investigate** <br>
-Read only: **True**
+Type: **generic** <br>
+Read only: **False**
 
 #### Action Parameters
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Rejected attachment filenames containing line breaks to prevent RT field injection. (PAPP-37978)
 * Reclassified get attachment as a vault-writing action subject to normal execution controls. (PAPP-37978)
 * Prevented get attachment from vaulting HTTP error responses as file content. (PAPP-37978)
+* Reported RT in-body rejections from update ticket and add attachment actions as failures. (PAPP-37978)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Updated development tooling. (PAPP-37978)
+* Fixed credential handling to keep passwords out of request URLs and diagnostic logs. (PAPP-37978)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Fixed credential handling to keep passwords out of request URLs and diagnostic logs. (PAPP-37978)
+* Rejected attachment filenames containing line breaks to prevent RT field injection. (PAPP-37978)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Updated development tooling. (PAPP-37978)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Fixed credential handling to keep passwords out of request URLs and diagnostic logs. (PAPP-37978)
 * Rejected attachment filenames containing line breaks to prevent RT field injection. (PAPP-37978)
+* Reclassified get attachment as a vault-writing action subject to normal execution controls. (PAPP-37978)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Fixed credential handling to keep passwords out of request URLs and diagnostic logs. (PAPP-37978)
 * Rejected attachment filenames containing line breaks to prevent RT field injection. (PAPP-37978)
 * Reclassified get attachment as a vault-writing action subject to normal execution controls. (PAPP-37978)
+* Prevented get attachment from vaulting HTTP error responses as file content. (PAPP-37978)

--- a/requesttracker.json
+++ b/requesttracker.json
@@ -18,7 +18,7 @@
     "fips_compliant": true,
     "logo": "logo_bestpractical.svg",
     "logo_dark": "logo_bestpractical_dark.svg",
-    "license": "Copyright (c) 2016-2025 Splunk Inc.",
+    "license": "Copyright (c) 2016-2026 Splunk Inc.",
     "python_version": "3.9, 3.13",
     "configuration": {
         "device_url": {

--- a/requesttracker.json
+++ b/requesttracker.json
@@ -1074,9 +1074,9 @@
         {
             "action": "get attachment",
             "description": "Download attachment to vault",
-            "type": "investigate",
+            "type": "generic",
             "identifier": "get_attachment",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "id": {
                     "description": "Ticket ID",

--- a/requesttracker_connector.py
+++ b/requesttracker_connector.py
@@ -83,8 +83,6 @@ class RTConnector(BaseConnector):
         error_code = None
         error_msg = ERROR_MSG_UNAVAILABLE
 
-        self.error_print("Error occurred.", e)
-
         try:
             if hasattr(e, "args"):
                 if len(e.args) > 1:
@@ -101,6 +99,7 @@ class RTConnector(BaseConnector):
             error_text = f"Error Code: {error_code}. Error Message: {error_msg}"
 
         error_text = re.sub(r"pass=[^\s]*", "pass=[masked]", error_text)
+        self.error_print("Error occurred.", error_text)
         return error_text
 
     def _process_empty_reponse(self, response, action_result):
@@ -232,11 +231,11 @@ class RTConnector(BaseConnector):
         return self._process_response(r, action_result)
 
     def _create_rt_session(self, action_result):
-        params = None
+        data = None
         if self._username and self._password:
-            params = {"user": self._username, "pass": self._password}
+            data = {"user": self._username, "pass": self._password}
 
-        ret_val, _response = self._make_rest_call("", action_result, params=params, headers=None)
+        ret_val, _response = self._make_rest_call("", action_result, data=data, headers=None, method="post")
 
         return ret_val
 

--- a/requesttracker_connector.py
+++ b/requesttracker_connector.py
@@ -723,6 +723,9 @@ class RTConnector(BaseConnector):
         if not file_info["name"]:
             file_info["name"] = vault_id
 
+        if "\r" in file_info["name"] or "\n" in file_info["name"]:
+            return action_result.set_status(phantom.APP_ERROR, "Vault file name cannot contain line breaks")
+
         # Create payload for request
         content = {"content": "Action: comment\nText: {}\nAttachment: {}".format(comment, file_info["name"])}
         upfile = {"attachment_1": (file_info["name"], open(file_info["path"], "rb"), file_content_type)}

--- a/requesttracker_connector.py
+++ b/requesttracker_connector.py
@@ -226,7 +226,12 @@ class RTConnector(BaseConnector):
             )
 
         if self.get_action_identifier() == self.ACTION_ID_GET_ATTACHMENT and endpoint.endswith("content"):
-            return phantom.APP_SUCCESS, r
+            if 200 <= r.status_code < 300:
+                return phantom.APP_SUCCESS, r
+            message = "Error downloading attachment content. Status Code: {} Data from server: {}".format(
+                r.status_code, r.text.replace("{", "{{").replace("}", "}}")
+            )
+            return RetVal(action_result.set_status(phantom.APP_ERROR, message), None)
 
         return self._process_response(r, action_result)
 
@@ -651,11 +656,11 @@ class RTConnector(BaseConnector):
         # Request the attachment content
         ret_val, response = self._make_rest_call(f"ticket/{ticket_id}/attachments/{attachment_id}/content", action_result)
 
-        # Convert to bytes and strip away headers and trailers.
-        content = response.content
-
         if phantom.is_fail(ret_val):
             return ret_val
+
+        # Convert to bytes and strip away headers and trailers.
+        content = response.content
 
         # find first newline
         skip = content.find(b"\n")

--- a/requesttracker_connector.py
+++ b/requesttracker_connector.py
@@ -1,6 +1,6 @@
 # File: requesttracker_connector.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -236,7 +236,7 @@ class RTConnector(BaseConnector):
         if self._username and self._password:
             params = {"user": self._username, "pass": self._password}
 
-        ret_val, response = self._make_rest_call("", action_result, params=params, headers=None)
+        ret_val, _response = self._make_rest_call("", action_result, params=params, headers=None)
 
         return ret_val
 
@@ -728,7 +728,7 @@ class RTConnector(BaseConnector):
         content = {"content": "Action: comment\nText: {}\nAttachment: {}".format(comment, file_info["name"])}
         upfile = {"attachment_1": (file_info["name"], open(file_info["path"], "rb"), file_content_type)}
 
-        ret_val, resp_text = self._make_rest_call(f"ticket/{ticket_id}/comment", action_result, data=content, files=upfile, method="post")
+        ret_val, _resp_text = self._make_rest_call(f"ticket/{ticket_id}/comment", action_result, data=content, files=upfile, method="post")
 
         if phantom.is_fail(ret_val):
             return ret_val

--- a/requesttracker_connector.py
+++ b/requesttracker_connector.py
@@ -293,6 +293,28 @@ class RTConnector(BaseConnector):
         self.save_progress("Test Connectivity Passed")
         return phantom.APP_SUCCESS
 
+    def _check_rt_write_rejection(self, resp_text, action_result, operation):
+        rejection_markers = (
+            "not allowed",
+            "syntax error",
+            "illegal value",
+            "does not exist",
+            "could not",
+            "permission denied",
+            "credentials required",
+            "invalid",
+        )
+        for line in (resp_text or "").splitlines():
+            if not line.startswith("#"):
+                continue
+            lowered = line.lower()
+            if "unknown field" in lowered:
+                continue
+            if any(marker in lowered for marker in rejection_markers):
+                detail = line.lstrip("# ").strip()
+                return action_result.set_status(phantom.APP_ERROR, f"RT rejected the {operation}: {detail}")
+        return phantom.APP_SUCCESS
+
     def _update_ticket(self, param):
         action_result = self.add_action_result(ActionResult(param))
 
@@ -344,6 +366,9 @@ class RTConnector(BaseConnector):
                 if line.startswith("#") and "Unknown field" in line:
                     self.debug_print("WARNING: {} is an unknown field and was not included in ticket update".format(line.split(":")[0][2:]))
 
+            if phantom.is_fail(self._check_rt_write_rejection(resp_text, action_result, "ticket edit")):
+                return action_result.get_status()
+
         if comment:
             self.save_progress("Adding comment")
 
@@ -357,6 +382,9 @@ class RTConnector(BaseConnector):
 
             if phantom.is_fail(ret_val):
                 return ret_val
+
+            if phantom.is_fail(self._check_rt_write_rejection(resp_text, action_result, "ticket comment")):
+                return action_result.get_status()
 
         self.save_progress("Ticket updated")
 
@@ -735,10 +763,13 @@ class RTConnector(BaseConnector):
         content = {"content": "Action: comment\nText: {}\nAttachment: {}".format(comment, file_info["name"])}
         upfile = {"attachment_1": (file_info["name"], open(file_info["path"], "rb"), file_content_type)}
 
-        ret_val, _resp_text = self._make_rest_call(f"ticket/{ticket_id}/comment", action_result, data=content, files=upfile, method="post")
+        ret_val, resp_text = self._make_rest_call(f"ticket/{ticket_id}/comment", action_result, data=content, files=upfile, method="post")
 
         if phantom.is_fail(ret_val):
             return ret_val
+
+        if phantom.is_fail(self._check_rt_write_rejection(resp_text, action_result, "attachment comment")):
+            return action_result.get_status()
 
         return action_result.set_status(phantom.APP_SUCCESS, RT_SUCC_ADD_ATTACHMENT)
 

--- a/requesttracker_consts.py
+++ b/requesttracker_consts.py
@@ -1,6 +1,6 @@
 # File: requesttracker_consts.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- keep RT credentials out of request URLs and redact them before diagnostic logging
- reject unsafe attachment filenames and fail closed on attachment download errors
- classify vault-writing correctly and detect RT in-body write rejections

## Tracking

- PAPP-37978
- PSAAS-30888 / VULN-93613 / FS-1709
- PSAAS-31489 / VULN-94214 / FS-2652
- PSAAS-31572 / VULN-94297 / FS-2747
- PSAAS-31779 / VULN-94504 / FS-3026
- PSAAS-31830 / VULN-94554 / FS-3076
- PSAAS-31909 / VULN-94633 / FS-3155
- PSAAS-32247 / VULN-94970 / FS-3493

## Validation

- pre-commit run --all-files
- python3 -m py_compile requesttracker_connector.py requesttracker_consts.py
- python3 -m json.tool requesttracker.json
- git diff --check

Written by Codex.